### PR TITLE
Updated French Localization

### DIFF
--- a/Localizations/fr.lproj/Localizable.strings
+++ b/Localizations/fr.lproj/Localizable.strings
@@ -13,7 +13,7 @@
 "Stop charging" = "Arrêtez recharge";
 "Start charging" = "Démarrer recharge";
 "Set limit:" = "Définir limite:";
-"Charge limit:" = "Limite charge:";
+"Charge limit:" = "Limite char.:";
 "Refreshing..." = "Mise à jour...";
 "Please input your Tesla username and password" = "Veuillez saisir votre nom d'utilisateur et votre mot de passe Tesla";
 "Username" = "Nom d'utilisateur";


### PR DESCRIPTION
Fine tune this, so it stays on one line, and not hide the percentage. Should be fine now, as it's exactly same length as the English string without compromising the meaning. 