### PR TITLE
Update German localization 

### DIFF
--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -169,7 +169,7 @@
 "W" = "W";
 "NW" = "NW";
 
-"Auto-enable remote start on unlock" = "Fernstart beim aufschließen automatisch aktivieren";
+"Auto-enable remote start on unlock" = "Fernstart beim Aufschließen automatisch aktivieren";
 "Climate" = "Klima";
 "Lock" = "Verschließen";
 "Unlock" = "Aufschließen";
@@ -289,5 +289,5 @@
 "Where do you want to go?" = "Where do you want to go?";
 "Set navigation destination to ${destination}" = "Set navigation destination to ${destination}";
 
-"Vent sunroof" = "Lüften Schiebedach";
-"Close sunroof" = "Schließen Schiebedach";
+"Vent sunroof" = "Kippe Schiebedach";
+"Close sunroof" = "Schließe Schiebedach";


### PR DESCRIPTION
Fixed two typos and added one suggestion for a different expression in the German localization.

"Auto-enable remote start on unlock" = "Fernstart beim Aufschließen automatisch aktivieren";
"Close sunroof" = "Schließe Schiebedach";

"Vent sunroof" = "Kippe Schiebedach";
It is shorter than the translation of open slightly and since it is for the Siri, maybe there is/will be an open command which might be confusing. 
"Kippen" is the thing you do, when opening a window in a house just a crack. I think the translation is fitting. I don't have access to a model S, it sure would be nice to know which translation is being used there. [Here](https://youtu.be/b5a3n-vTtuU?t=40) is a video of the sunroof in that setting.
Hope it helps. :) 
