### PR TITLE
fixed german translation. close window for opening

### DIFF
--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -52,8 +52,8 @@
 "Homelink" = "Homelink";
 "Disable Sentry" = "Sentry deaktivieren";
 "Enable Sentry" = "Sentry aktivieren";
-"Vent" = "Lüften";
-"%@ windows" = "Fenster zum %@ öffnen";
+"Vent" = "einen Spalt öffen";
+"%@ windows" = "Fenster %@ ";
 "Location of %@" = "Position von %@";
 "Location" = "Position";
 "Flash!" = "Lichthupe!";


### PR DESCRIPTION

![IMG_1333_](https://user-images.githubusercontent.com/6443033/132014833-544073f5-586c-4db7-a636-f356abffeb29.png)
This is correct. However: 

![IMG_0916_](https://user-images.githubusercontent.com/6443033/132014826-bb752cbf-fe45-4d5e-9913-5da0e94d63c0.png)

This translates to "Open Windows for Closing". I changed the base string and the verb. It now translates to "Close Window" and "Open Window a crack" (Spalt). Tesla uses the same word for the venting case in their app.  

(However, if you use that string on line 55 somewhere else in the app by itself it might be not as nice as the phrase is longer now, but would still make sense. )